### PR TITLE
Spacing improvements to the cookie consent

### DIFF
--- a/packages/react/src/components/cookieConsent/CookieConsent.module.scss
+++ b/packages/react/src/components/cookieConsent/CookieConsent.module.scss
@@ -43,7 +43,7 @@
 
 .content {
   position: relative;
-  padding: var(--common-spacing) var(--common-spacing) 0 var(--common-spacing);
+  padding-top: var(--common-spacing);
   background: #ffffff;
   width: 100%;
   box-sizing: border-box;
@@ -80,7 +80,7 @@
 }
 
 .text-content > p {
-  padding-bottom: var(--spacing-2-xl);
+  padding-bottom: var(--spacing-l);
 }
 
 .main-content {
@@ -149,7 +149,7 @@
 
 .consent-group-parent {
   display: flex;
-  padding-bottom: var(--spacing-m);
+  padding-bottom: var(--spacing-l);
   flex-direction: column;
   > p {
     margin-bottom: 0;
@@ -160,7 +160,7 @@
   display: flex;
   position: relative;
   padding: var(--spacing-m) 0;
-  margin-left: var(--spacing-xs);
+  margin-left: 0;
   flex-direction: column;
   border-bottom: 1px solid var(--color-black);
 }
@@ -170,7 +170,7 @@
   padding: 0;
   flex-direction: column;
   p {
-    padding: var(--spacing-l) 0 0;
+    padding: var(--spacing-m) 0 0;
     margin: 0;
   }
   button {
@@ -253,6 +253,10 @@
     padding-top: 0;
   }
 
+  .text-content > p {
+    padding-bottom: var(--spacing-2-xl);
+  }
+
   .content .emulated-h1 {
     margin-right: 200px;
   }
@@ -268,6 +272,9 @@
 
   .consent-group-content {
     padding: 0 var(--spacing-l);
+    p {
+      padding: var(--spacing-l) 0 0;
+    }
   }
 
   .buttons {

--- a/packages/react/src/components/cookieConsent/CookieConsent.module.scss
+++ b/packages/react/src/components/cookieConsent/CookieConsent.module.scss
@@ -159,7 +159,8 @@
 .consent-group {
   display: flex;
   position: relative;
-  padding: var(--spacing-l) 0;
+  padding: var(--spacing-m) 0;
+  margin-left: var(--spacing-xs);
   flex-direction: column;
   border-bottom: 1px solid var(--color-black);
 }
@@ -261,11 +262,12 @@
   }
 
   .consent-group {
-    padding: var(--spacing-xl) 0;
+    padding: var(--spacing-l) 0;
+    margin-left: var(--spacing-s);
   }
 
   .consent-group-content {
-    padding: 0 var(--spacing-m);
+    padding: 0 var(--spacing-l);
   }
 
   .buttons {


### PR DESCRIPTION
## Description
Small layout improvements to both desktop and mobile variants.

## Known issues
- Cookie consent now takes the full width of the viewport. It should follow the HDS content width tokens.
- The Accordion angle-down icon is slightly misplaced on smaller screens

## Screenshots (if appropriate):
<img width="1242" alt="image" src="https://user-images.githubusercontent.com/4214671/166233997-616c6791-2f4f-4559-9bcd-fdef13897988.png">

<img width="501" alt="image" src="https://user-images.githubusercontent.com/4214671/166233975-ccc983c9-3a66-4475-93d5-0a49a2b40eee.png">
