### PR TITLE
Prevent errors when CookieModal or CookiePage in SSR

### DIFF
--- a/packages/react/src/components/cookieConsent/cookieConsentController.ts
+++ b/packages/react/src/components/cookieConsent/cookieConsentController.ts
@@ -65,7 +65,13 @@ function createConsentsString(consents: ConsentObject): string {
   return JSON.stringify(consents);
 }
 
-export const getCookieDomainFromUrl = (): string => window.location.hostname.split('.').slice(-2).join('.');
+export const getCookieDomainFromUrl = (): string => {
+  if (typeof window === 'undefined') {
+    return '';
+  }
+
+  return window.location.hostname.split('.').slice(-2).join('.');
+};
 
 export function createStorage(
   initialValues: ConsentStorage,

--- a/packages/react/src/components/cookieConsent/cookieController.ts
+++ b/packages/react/src/components/cookieConsent/cookieController.ts
@@ -34,6 +34,13 @@ function createCookieController(
     ...options,
   };
 
+  if (typeof window === 'undefined') {
+    return {
+      get: () => '',
+      set: () => '',
+    };
+  }
+
   const getCookie = (): string => getNamedCookie(cookieName) || '';
 
   const setCookie = (data: string): void => {


### PR DESCRIPTION
## Description
- Check if window object is available before accessing or running window.object properties

## Related Issue
- https://helsinkisolutionoffice.atlassian.net/browse/HDS-1339

## Motivation and Context
- HDS supports components server side rendering in a way that it at least does not cause errors on builds.

## How Has This Been Tested?
- Locally on dev machine

[Demo](https://city-of-helsinki.github.io/hds-demo/docs-cookie-settings-analytics)